### PR TITLE
Revert "Update frontend networks" - puts back deleted networks

### DIFF
--- a/frontend/src/lib/networks.ts
+++ b/frontend/src/lib/networks.ts
@@ -1,5 +1,3 @@
-import { erc20Tokens, type ERC20Token } from "./tokens"
-
 export type ChainID = number
 
 export type Network = {
@@ -36,7 +34,7 @@ export type Network = {
 }
 
 export const networks: Network[] = [
-  {
+	{
 		"slug": "ethereum",
 		"name": "Ethereum",
 		"chainId": 1,
@@ -67,6 +65,61 @@ export const networks: Network[] = [
 			"registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
 		},
 		"icon": "ethereum",
+	},
+	{
+		"slug": "ethereum-goerli",
+		"name": "Ethereum Görli Testnet",
+		"chainId": 5,
+		"shortName": "gor",
+		"chain": "ETH",
+		"network": "goerli",
+		"networkId": 5,
+		"nativeCurrency": {
+			"name": "Görli Ether",
+			"symbol": "GOR",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://rpc.goerli.mudit.blog/",
+			"https://rpc.slock.it/goerli ",
+			"https://goerli.prylabs.net/"
+		],
+		"faucets": [
+			"https://goerli-faucet.slock.it/?address=${ADDRESS}",
+			"https://faucet.goerli.mudit.blog"
+		],
+		"explorers": [],
+		"infoURL": "https://goerli.net/#about",
+		"ens": {
+			"registry": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+		}
+	},
+	{
+		"slug": "ethereum-kovan",
+		"name": "Ethereum Kovan Testnet",
+		"chainId": 42,
+		"shortName": "kov",
+		"chain": "ETH",
+		"network": "kovan",
+		"networkId": 42,
+		"nativeCurrency": {
+			"name": "Kovan Ether",
+			"symbol": "KOV",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://kovan.poa.network",
+			"http://kovan.poa.network:8545",
+			"https://kovan.infura.io/v3/${INFURA_PROJECT_ID}",
+			"wss://kovan.infura.io/ws/v3/${INFURA_PROJECT_ID}",
+			"ws://kovan.poa.network:8546"
+		],
+		"faucets": [
+			"https://faucet.kovan.network",
+			"https://gitter.im/kovan-testnet/faucet"
+		],
+		"explorers": [],
+		"infoURL": "https://kovan-testnet.github.io/website"
 	},
 	{
 		"slug": "ethereum-rinkeby",
@@ -100,6 +153,33 @@ export const networks: Network[] = [
 			"registry": "0xe7410170f87102df0055eb195163a03b7f2bff4a"
 		}
 	},
+	{
+		"slug": "ethereum-ropsten",
+		"name": "Ethereum Ropsten Testnet",
+		"chainId": 3,
+		"shortName": "rop",
+		"chain": "ETH",
+		"network": "ropsten",
+		"networkId": 3,
+		"nativeCurrency": {
+			"name": "Ropsten Ether",
+			"symbol": "ROP",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://ropsten.infura.io/v3/${INFURA_PROJECT_ID}",
+			"wss://ropsten.infura.io/ws/v3/${INFURA_PROJECT_ID}"
+		],
+		"faucets": [
+			"https://faucet.ropsten.be?${ADDRESS}"
+		],
+		"explorers": [],
+		"infoURL": "https://github.com/ethereum/ropsten",
+		"ens": {
+			"registry": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+		}
+	},
+
 	{
 		"slug": "polygon",
 		"name": "Polygon",
@@ -249,9 +329,33 @@ export const networks: Network[] = [
 		"infoURL": "https://docs.celo.org/"
 	},
 	{
+		"slug": "celo-baklava",
+		"name": "Celo Baklava Testnet",
+		"chainId": 62320,
+		"shortName": "BKLV",
+		"chain": "CELO",
+		"network": "Baklava",
+		"networkId": 62320,
+		"nativeCurrency": {
+			"name": "CELO",
+			"symbol": "CELO",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://baklava-forno.celo-testnet.org"
+		],
+		"faucets": [
+			"https://docs.google.com/forms/d/e/1FAIpQLSdfr1BwUTYepVmmvfVUDRCwALejZ-TUva2YujNpvrEmPAX2pg/viewform",
+			"https://cauldron.pretoriaresearchlab.io/baklava-faucet"
+		],
+		"explorers": [],
+		"infoURL": "https://docs.celo.org/"
+	},
+
+	{
 		"slug": "metis",
 		"name": "Metis",
-		"chainId": 1088,
+		"chainId": 488, // 435
 		"nativeCurrency": {
 			"name": "Metis",
 			"symbol": "METIS",
@@ -259,23 +363,6 @@ export const networks: Network[] = [
 		},
 		"rpc": [
 			"https://dragonfire.metis.io/?owner=488",
-			// "https://rocketfuel.metis.io/?owner=435"
-		],
-		"faucets": [],
-		"explorers": [],
-		"infoURL": "https://www.metis.io"
-	},
-  {
-		"slug": "metis-stardust",
-		"name": "Metis Stardust",
-		"chainId": 588,
-		"nativeCurrency": {
-			"name": "Metis",
-			"symbol": "METIS",
-			"decimals": 18
-		},
-		"rpc": [
-			"https://stardust.metis.io/?owner=588",
 			// "https://rocketfuel.metis.io/?owner=435"
 		],
 		"faucets": [],
@@ -323,6 +410,26 @@ export const networks: Network[] = [
 		"explorers": [],
 		"infoURL": "https://aurora.dev"
 	},
+	{
+		"slug": "aurora-betanet",
+		"name": "Aurora BetaNet",
+		"chainId": 1313161556,
+		"shortName": "aurora-betanet",
+		"chain": "NEAR",
+		"network": "betanet",
+		"networkId": 1313161556,
+		"nativeCurrency": {
+			"name": "Ether",
+			"symbol": "aETH",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://rpc.betanet.aurora.dev:8545"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://aurora.dev"
+	},
 
 	{
 		"slug": "harmony-shard0",
@@ -365,6 +472,134 @@ export const networks: Network[] = [
 		},
 		"rpc": [
 			"https://s1.api.harmony.one"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-shard2",
+		"name": "Harmony Shard 2",
+		"chainId": 1666600002,
+		"shortName": "hmy-s2",
+		"chain": "Harmony",
+		"network": "mainnet",
+		"networkId": 1666600002,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://s2.api.harmony.one"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-shard3",
+		"name": "Harmony Shard 3",
+		"chainId": 1666600003,
+		"shortName": "hmy-s3",
+		"chain": "Harmony",
+		"network": "mainnet",
+		"networkId": 1666600003,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://s3.api.harmony.one"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-testnet-shard0",
+		"name": "Harmony Testnet Shard 0",
+		"chainId": 1666700000,
+		"shortName": "hmy-b-s0",
+		"chain": "Harmony",
+		"network": "testnet",
+		"networkId": 1666700000,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://api.s0.b.hmny.io"
+		],
+		"faucets": [
+			"https://faucet.pops.one"
+		],
+		"explorers": [
+			{
+				"name": "Harmony Testnet Block Explorer",
+				"url": "https://explorer.pops.one",
+				"standard": "EIP3091"
+			}
+		],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-testnet-shard1",
+		"name": "Harmony Testnet Shard 1",
+		"chainId": 1666700001,
+		"shortName": "hmy-b-s1",
+		"chain": "Harmony",
+		"network": "testnet",
+		"networkId": 1666700001,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://api.s1.b.hmny.io"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-testnet-shard2",
+		"name": "Harmony Testnet Shard 2",
+		"chainId": 1666700002,
+		"shortName": "hmy-b-s2",
+		"chain": "Harmony",
+		"network": "testnet",
+		"networkId": 1666700002,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://api.s2.b.hmny.io"
+		],
+		"faucets": [],
+		"explorers": [],
+		"infoURL": "https://www.harmony.one/"
+	},
+	{
+		"slug": "harmony-testnet-shard3",
+		"name": "Harmony Testnet Shard 3",
+		"chainId": 1666700003,
+		"shortName": "hmy-b-s3",
+		"chain": "Harmony",
+		"network": "testnet",
+		"networkId": 1666700003,
+		"nativeCurrency": {
+			"name": "ONE",
+			"symbol": "ONE",
+			"decimals": 18
+		},
+		"rpc": [
+			"https://api.s3.b.hmny.io"
 		],
 		"faucets": [],
 		"explorers": [],


### PR DESCRIPTION
Reverts ethdenver-nft-owned-dao-creator/DAOCreator#7

puts back deleted networks